### PR TITLE
add docs for running the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 `pg-eyeballs` is a ruby gem that gives you detailed information about how the
 SQL queries created by the active record code you write are executed by the database.
 It gives you an easy, ruby friendly way to see the output of the Postgres
-[`EXPLAIN` command](https://www.postgresql.org/docs/9.4/static/using-explain.html) and integrates with the popular query analysis tool [`gocmdpev`](https://github.com/simon-engledew/gocmdpev). 
+[`EXPLAIN` command](https://www.postgresql.org/docs/9.4/static/using-explain.html) and integrates with the popular query analysis tool [`gocmdpev`](https://github.com/simon-engledew/gocmdpev).
 
 Using it you can see:
 - What queries were run
@@ -48,7 +48,7 @@ more than one query, for instance when it has a `preload` or with certain
 subqueries
 ```ruby
 User.all.preload(:profiles).eyeballs.explain(options: [:verbose], format: :yaml)
-['- Plan: 
+['- Plan:
       Node Type: "Seq Scan"
       Relation Name: "users"
       Schema: "public"
@@ -57,10 +57,10 @@ User.all.preload(:profiles).eyeballs.explain(options: [:verbose], format: :yaml)
       Total Cost: 22.30
       Plan Rows: 1230
       Plan Width: 36
-      Output: 
+      Output:
       - "id"
-      - "email"', 
- '- Plan:     
+      - "email"',
+ '- Plan:
       Node Type: "Seq Scan"
       Relation Name: "profiles"
       Schema: "public"
@@ -69,7 +69,7 @@ User.all.preload(:profiles).eyeballs.explain(options: [:verbose], format: :yaml)
       Total Cost: 36.75
       Plan Rows: 11
       Plan Width: 8
-      Output: 
+      Output:
         - "id"
         - "user_id"
       Filter: "(profiles.user_id = 1)"'
@@ -189,8 +189,13 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/bradurani/pg-eyeballs. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
+### Running the tests
+
+First, `bundle install`. After this, if you are using the default
+database, first thing is to run `createdb eyeballs_test`. After this
+you can run the tests with `rake`.
+
 
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-


### PR DESCRIPTION
I think most folks understand to `createdb` when they get the database doesn't exist error,
but we can make that path a bit easier for new developers by documenting it in the readme.
