### PR TITLE
Tweak Rails 5 code to support LIMIT/OFFSET

### DIFF
--- a/lib/eyeballs/inspector.rb
+++ b/lib/eyeballs/inspector.rb
@@ -109,10 +109,9 @@ module Eyeballs
     def extract_value(value)
       if value.is_a?(Array) #Rails 4
         value.last
-      elsif value.is_a?(ActiveRecord::Relation::QueryAttribute) #Rails 5
+      elsif value.respond_to?(:value) #Rails 5
         value.value
       end
     end
-
   end
 end

--- a/spec/eyeballs/inspector_spec.rb
+++ b/spec/eyeballs/inspector_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
 describe Eyeballs::Inspector do
-
   let(:foo){ Foo.all.eyeballs }
   let(:foo_bar) do
     Foo.all.preload(:bars).eyeballs
   end
-
+  let(:foo_paginate) { Foo.limit(10).offset(0).all.eyeballs }
 
   describe :queries do
     context :foo do
@@ -21,6 +20,13 @@ describe Eyeballs::Inspector do
         expect(foo_bar.queries.length).to eql 2 
         expect(foo_bar.queries[0]).to include 'SELECT "foos".* FROM "foos"'
         expect(foo_bar.queries[1]).to include 'SELECT "bars".* FROM "bars"'
+      end
+    end
+
+    context :foo_paginate do
+      it 'returns array of queries' do
+        expect(foo_paginate.queries.length).to eql 1
+        expect(foo_paginate.queries[0]).to include "LIMIT 10 OFFSET 0"
       end
     end
   end
@@ -130,5 +136,4 @@ describe Eyeballs::Inspector do
       expect(output).to be_nil
     end
   end
-
 end


### PR DESCRIPTION
When LIMIT/OFFSET are used in a query, `extract_value` replaces their values with `nil` since the values in the query array are of type `ActiveModel::Attribute::WithCastValue` not `ActiveRecord::Relation::QueryAttribute`. I've updated the method to ask if the objects have a `value` method and to always call it if they do instead of querying their types.